### PR TITLE
Bug fixes and cleanup for translateText and summarizeText

### DIFF
--- a/src/summarizeText.py
+++ b/src/summarizeText.py
@@ -30,7 +30,7 @@ def summarize(text):
 
     #Create dictionary to track sentence scores
     sentenceScores = dict()
-       
+
     #For loop to tally sentence scores
     for j in sents:
         for i, count in wordScores.items():
@@ -39,20 +39,20 @@ def summarize(text):
                     sentenceScores[j] += count
                 else:
                     sentenceScores[j] = count
-      
+
     #Initialize sum
     sentenceScoresSum = 0
     
     #Tally sum
     for j in sentenceScores:
         sentenceScoresSum += sentenceScores[j]
-       
+
     #Initialize summary
     summary_text = ''
     
     #Build summary
     for j in sents:
-        if (j in sentenceScores) and (sentenceScores[j] > (1.2 * (int(sentenceScoresSum / len(sentenceScores))))):
+        if (j in sentenceScores) and (sentenceScores[j] > (1.2 * ((sentenceScoresSum / len(sentenceScores))))):
             summary_text += " " + j
 
     return summary_text

--- a/src/translateText.py
+++ b/src/translateText.py
@@ -1,5 +1,30 @@
 from translate import Translator
-from nltk.tokenize import sent_tokenize
+from nltk.tokenize import sent_tokenize, word_tokenize
+
+# implemented to avoid 500 char query limit
+def word_boundary(text, char_limit):
+    char_tokens = []
+    current_chunk = []
+    current_length = 0
+
+    for sentence in text:
+        words = word_tokenize(sentence)
+
+        for word in words:
+            word_length = len(word)
+
+            if current_length + word_length + len(current_chunk) <= char_limit:
+                current_chunk.append(word)
+                current_length += word_length
+            else:
+                char_tokens.append(" ".join(current_chunk))
+                current_chunk = [word]
+                current_length = word_length
+
+    if current_chunk:
+        char_tokens.append(" ".join(current_chunk))
+
+    return char_tokens
 
 def translate(text):
     translator= Translator(from_lang='es', to_lang='en')
@@ -8,5 +33,7 @@ def translate(text):
     # Loop through each sentence to translate
     sents = sent_tokenize(text)
     for i in sents:
-        translation += " " + translator.translate(i)
+        # Calculate each word boundary of 500 characters or less
+        for j in word_boundary(i, 500):
+            translation += " " + translator.translate(j)
     return translation

--- a/src/translateText.py
+++ b/src/translateText.py
@@ -1,6 +1,12 @@
 from translate import Translator
+from nltk.tokenize import sent_tokenize
 
 def translate(text):
     translator= Translator(from_lang='es', to_lang='en')
-    translation = translator.translate(text)
+    translation = ''
+
+    # Loop through each sentence to translate
+    sents = sent_tokenize(text)
+    for i in sents:
+        translation += translator.translate(i)
     return translation

--- a/src/translateText.py
+++ b/src/translateText.py
@@ -8,5 +8,5 @@ def translate(text):
     # Loop through each sentence to translate
     sents = sent_tokenize(text)
     for i in sents:
-        translation += translator.translate(i)
+        translation += " " + translator.translate(i)
     return translation


### PR DESCRIPTION
This breaks the translateText into sentences/chunks to avoid the 500 character limit error. summarizeText yielded an error with the int. All have been resolved and seem to be working as intended.